### PR TITLE
Make GitHub detect cmd-* as MUF.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+cmd-* linguist-language=MUF


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect the `cmd-*` files as MUF.

Thanks!